### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,8 @@ jobs:
     name: Test and upload code coverage
     runs-on: ubuntu-latest
     environment: dev
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/yavurb/goyurback/security/code-scanning/1](https://github.com/yavurb/goyurback/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to limit the permissions of the `GITHUB_TOKEN`. The minimal safe default is `contents: read`, which allows the workflow to read repository contents but not write or modify them. Since the steps in the job only require reading code (for checkout, running tests, and uploading coverage), no write permissions are needed. The best place to add the `permissions` block is at the job level (inside the `test` job definition) or at the workflow root. For clarity and to scope the permissions only to the job flagged (the `test` job), we will add the following block above the `steps:` key on line 25:

```yaml
permissions:
  contents: read
```

This ensures the job only gets read access to contents, and not unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
